### PR TITLE
Update supported message types for Copilot in channel.md

### DIFF
--- a/concepts/bot_connector/channel.md
+++ b/concepts/bot_connector/channel.md
@@ -116,7 +116,7 @@ If a channel doesn't natively support a rich format, Bot Connector will handle i
         <td class="center"><i class="c-blue-500 ion-md-checkmark-circle"></i></td>
         <td class="center"><i class="c-blue-500 ion-md-checkmark-circle"></i></td>
         <td class="center"><i class="c-grey-400 ion-md-close"></i></td>
-        <td class="center"><i class="c-blue-500 ion-md-checkmark-circle"></i></td>
+        <td class="center"><i class="c-blue-500 ion-md-close"></i></td>
     </tr>
     <tr>
         <td>Card</td>
@@ -152,7 +152,7 @@ If a channel doesn't natively support a rich format, Bot Connector will handle i
         <td class="center"><i class="c-grey-400 ion-md-close"></i></td>
         <td class="center"><i class="c-grey-400 ion-md-close"></i></td>
         <td class="center"><i class="c-grey-400 ion-md-close"></i></td>
-        <td class="center"><i class="c-blue-500 ion-md-checkmark-circle"></i></td>
+        <td class="center"><i class="c-blue-500 ion-md-close"></i></td>
     </tr>
     <tr>
         <td>Buttons</td>


### PR DESCRIPTION
reflect that Copilot does not support image and carousel message types