### PR TITLE
Update builder_messages.md

### DIFF
--- a/concepts/bot_builder/builder_messages.md
+++ b/concepts/bot_builder/builder_messages.md
@@ -54,7 +54,7 @@ You can dynamically inject the content gathered from the conversation in the bot
 You can create all of the following variables:
 
 * `{{conversation_id}}`: ID of the current conversation.
-* `{{participant_data}}`: An object filled with participant information that is provided by the channel connected through the Bot Connector. By default, you always have a `username`. You can easily use `{{participant_data.username}}`.
+* `{{participant_data}}`: An object filled with participant information that is provided by the channel connected through the Bot Connector. For example, for those channels that supply a username, it is returned as `userName`. You can easily use `{{participant_data.userName}}`.
 * `{{memory}}`: The complete memory object. You can access each element like `{{memory.person.raw}}`. Here, *person* is the alias of a requirement.
 * `{{skill_occurences}}`: Number of consecutive occurrences of the current skill.
 * `{{language}}`: Language ISO code of the current conversation.


### PR DESCRIPTION
Hi @janteuni  Hi @jhoudan Can you please check this update, based on the below feedback from Jessica Yeung in CoPilot? Merci!

A coworker and I were looking through the docs and noticed that the following point doesn’t seem to reflect the actual behaviour:

{{participant_data}}: An object filled with participant information that is provided by the channel connected through the Bot Connector. By default, you always have a username. You can easily use {{participant_data.username}}
 
Specifically, it seems like not all channels supply a username, and for the ones that do, it is returned as userName (in camelCase). 