### PR TITLE
Change separator in CSV file examples from comma to semicolon

### DIFF
--- a/concepts/monitor/training_analytics.md
+++ b/concepts/monitor/training_analytics.md
@@ -38,15 +38,15 @@ For multilingual bots, please upload one file for each supported language.
 
 **File format**
 
-Your file must be a valid CSV file. It must end with .csv and the separator must be a comma “,”. If you want to include quotes in your expressions or intents, you must add two double quotation marks before and after the quoted word(s).
+Your file must be a valid CSV file. It must end with .csv and the separator must be a semicolon “;”. If you want to include quotes in your expressions or intents, you must add two double quotation marks before and after the quoted word(s).
 For example, it should look like this:
 
 ~~~
-"intent","expression"
-"greetings","Hello"
-"greetings","Hi"
-"weather","What’s the weather in Paris?"
-"translation","What does ""Bonjour"" in French mean?"
+"intent";"expression"
+"greetings";"Hello"
+"greetings";"Hi"
+"weather";"What’s the weather in Paris?"
+"translation";"What does ""Bonjour"" in French mean?"
 ~~~
 
 <br/>

--- a/concepts/nlp_lexic/expression.md
+++ b/concepts/nlp_lexic/expression.md
@@ -41,9 +41,9 @@ By importing expressions, you can speed up the bot development process.
 
 Please format the CSV file as follows:
 ~~~ 
-"expression","language"
-"I want to travel to NYC","en"
-"Let's travel to New York!","en"
+"expression";"language"
+"I want to travel to NYC";"en"
+"Let's travel to New York!";"en"
 ~~~
 
 <br>


### PR DESCRIPTION
PE reported that semicolon is the correct delimiter in CSV files. In the CSV file examples in the documentation, this pull request therefore changes the separator from comma to semicolon.
I suggest we merge this pull request with the other updates for 1903.
However, we should also consider changing the delimiter from semicolon to comma in the platform because a CSV file is by definition a comma-separated file (rather than a semicolon-separated file!)